### PR TITLE
slightly extended the custom route parser example

### DIFF
--- a/examples/Custom.elm
+++ b/examples/Custom.elm
@@ -2,24 +2,25 @@ module Custom exposing (Category(..), Sitemap(..), match, route)
 
 {-| This module demonstrates how you can use custom parsers to parse
 paths.  This example parses routes like `/categories/snippet` and
-`/categories/post` into `CategoryR Snippet` and `CategoryR Post`,
+`/categories/post/5` into `CategoryR Snippet` and `CategoryR (Post 5)`,
 respectively.
 -}
 
 import Combine exposing (..)
+import Combine.Num
 import Route exposing (..)
 
 
 type Category
     = Snippet
-    | Post
+    | Post Int
 
 
 category : Parser s Category
 category =
     choice
         [ Snippet <$ Combine.string "snippet"
-        , Post <$ Combine.string "post"
+        , Post <$> (Combine.string "post/" *> Combine.Num.int)
         ]
 
 
@@ -29,8 +30,8 @@ show c =
         Snippet ->
             "snippet"
 
-        Post ->
-            "post"
+        Post id ->
+            "post/" ++ Basics.toString id
 
 
 type Sitemap

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -136,7 +136,7 @@ static s =
 
     type Category
       = Snippet
-      | Post
+      | Post Int
 
     type Sitemap
       = CategoryR Category
@@ -147,8 +147,8 @@ static s =
     > match sitemap "/categories/a"
     Nothing : Maybe Sitemap
 
-    > match sitemap "/categories/Post"
-    Just (CategoryR Post) : Maybe Sitemap
+    > match sitemap "/categories/Post/5"
+    Just (CategoryR (Post 5)) : Maybe Sitemap
 
     > match sitemap "/categories/Snippet"
     Just (CategoryR Snippet) : Maybe Sitemap


### PR DESCRIPTION
... to include parsing an `Int` parameter in the sub-route. Might help the next person who wants to make nested routes using this wonderful package.

I can extend the example a little more before merging if you think that would be helpful.